### PR TITLE
Adding GET to the list of queryable methods

### DIFF
--- a/src/spinnaker.coffee
+++ b/src/spinnaker.coffee
@@ -48,6 +48,10 @@ class SpinnakerProvider
       request = (url, data={}, method='get') ->
         deferred = $q.defer()
         socket[method] url, data, (data) ->
+          # For some reason, GETs by id don't return an array, so test for that case
+          if Object::toString.call(data) isnt "[object Array]"
+            dataArray = [data]
+            data = dataArray
           $rootScope.$apply ->
             return deferred.reject data if data.status?
             deferred.resolve data

--- a/src/spinnaker.coffee
+++ b/src/spinnaker.coffee
@@ -75,7 +75,7 @@ class SpinnakerProvider
         params ?= if instCall then @ else {}
         method = action.method ? 'get'
         method = action.method params if angular.isFunction action.method
-        data ?= params if /^(POST|PUT|PATCH|DELETE)$/i.test method
+        data ?= params if /^(GET|POST|PUT|PATCH|DELETE)$/i.test method
         resourceClass = action.resource ? Resource
         value = if action.isArray
           new ResourceCollection resourceClass, params, data, action.filter


### PR DESCRIPTION
GET needed to be added to the list of methods that would accept query params.

Fixes #1

@mattgi @adampilks If you're still using this lib, would you mind a quick test?
